### PR TITLE
173 products page change width to fit cards grid better on desktop view

### DIFF
--- a/components/products-list.tsx
+++ b/components/products-list.tsx
@@ -55,7 +55,7 @@ export default async function ProductsList({
     : "There are no products available at the moment.";
 
   return (
-    <section className="flex flex-col relative bg-white items-center pt-10 rounded-md shadow-md">
+    <section className="flex flex-col relative bg-white items-center pt-10 rounded-md shadow-md max-w-[1280px] mx-auto">
 
       <ProductsGrid
         products={products}


### PR DESCRIPTION
Added 1280px max width to product page
- Centered products grid on desktop